### PR TITLE
facilties synced from devicectl to nautobot sites will now set both n…

### DIFF
--- a/src/django_devicectl/models/devicectl.py
+++ b/src/django_devicectl/models/devicectl.py
@@ -71,8 +71,9 @@ class Facility(GeoModel, ServiceBridgeReferenceModel):
         # TODO: move outside of model definition ?
 
         map_nautobot = {
-            "name": "name",
+            "name": "slug",
             "slug": "slug",
+            "facility": "name",
             "custom_fields.devicectl_id": "fullctl_id",
             "physical_address": "address1",
             "latitude": "latitude",


### PR DESCRIPTION
- adjustments to how devicectl syncs facility slug and name to nautobot
  - devicectl.facility.slug -> nautobot.site.slug
  - devicectl.facility.slug -> nautobot.site.name
  - devicectl.facility.name -> nautobot.site.facility
