### PR TITLE
fix a typo in model

### DIFF
--- a/src/django_devicectl/models/devicectl.py
+++ b/src/django_devicectl/models/devicectl.py
@@ -300,7 +300,7 @@ class Device(ServiceBridgeReferenceModel):
     def management_ip_address_4(self):
         return self.management_port.ip_address_4
 
-    def managmeent_ip_address_6(self):
+    def management_ip_address_6(self):
         return self.management_port.ip_address_6
 
     def setup(self):


### PR DESCRIPTION
`managmeent_ip_address_6` -> `management_ip_address_6`

the method name does not seem to be called anywhere in FullCtl so this fix should be safe to merge