### PR TITLE
use the aaactl org id

### DIFF
--- a/src/django_devicectl/models/tasks.py
+++ b/src/django_devicectl/models/tasks.py
@@ -311,7 +311,9 @@ class UpdateIxctlIxTrafficGraphs(Task):
         for device in devices:
             ports += [vp.port.id for vp in device.virtual_ports if vp.port]
 
-        members = ixctl.InternetExchangeMember().objects(ports=ports, org_slug=self.org.permission_id)
+        members = ixctl.InternetExchangeMember().objects(
+            ports=ports, org_slug=self.org.permission_id
+        )
         for member in members:
             ix_ports.setdefault(member.ix_id, []).append(member.port)
 

--- a/src/django_devicectl/models/tasks.py
+++ b/src/django_devicectl/models/tasks.py
@@ -312,7 +312,7 @@ class UpdateIxctlIxTrafficGraphs(Task):
             ports += [vp.port.id for vp in device.virtual_ports if vp.port]
 
         members = ixctl.InternetExchangeMember().objects(
-            ports=ports, org_slug=self.org.permission_id
+            ports=ports, org=self.org.remote_id
         )
         for member in members:
             ix_ports.setdefault(member.ix_id, []).append(member.port)

--- a/src/django_devicectl/models/tasks.py
+++ b/src/django_devicectl/models/tasks.py
@@ -311,7 +311,7 @@ class UpdateIxctlIxTrafficGraphs(Task):
         for device in devices:
             ports += [vp.port.id for vp in device.virtual_ports if vp.port]
 
-        members = ixctl.InternetExchangeMember().objects(ports=ports, org=self.org.id)
+        members = ixctl.InternetExchangeMember().objects(ports=ports, org_slug=self.org.permission_id)
         for member in members:
             ix_ports.setdefault(member.ix_id, []).append(member.port)
 


### PR DESCRIPTION
needs https://github.com/fullctl/ixctl/pull/113/files

When generating total ix traffic graphs, use the aaactl organization id for cross-checking with ixctl
